### PR TITLE
Sitio estático

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,3 +19,14 @@ jobs:
       - name: Run build
         run: |
           deno run --allow-read --allow-write --allow-net scripts/build.js
+      
+      - name: Generate the static site
+        run: |
+          deno run --unstable -A https://deno.land/x/lume/cli.js --root=web
+
+      - name: Deploy site
+        uses: crazy-max/ghaction-github-pages@v2.0.1
+        with:
+          build_dir: web/_site
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 # misc
 .DS_Store
 *.pem
+
+web/_site

--- a/README.md
+++ b/README.md
@@ -13,10 +13,17 @@ Para crear o arquivo `dist/api.json` co que funcionará a API:
 deno run --allow-read --allow-write --allow-net scripts/build.js
 ```
 
-Para levantar un servidor local en http://localhost:3000
+Para levantar un servidor local para a API http://localhost:3000
 
 ```
 deno run --allow-read --allow-net scripts/server.js
+```
+
+Para levantar un servidor local cunha web en html http://localhost:3000
+
+```
+cd web
+deno run --unstable -A https://deno.land/x/lume/cli.js --serve
 ```
 
 ## Validar os YAML en VSCode

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ deno run --allow-read --allow-net scripts/server.js
 Para levantar un servidor local cunha web en html http://localhost:3000
 
 ```
-cd web
-deno run --unstable -A https://deno.land/x/lume/cli.js --serve
+deno run --unstable -A https://deno.land/x/lume/cli.js --serve --root=web
 ```
 
 ## Validar os YAML en VSCode

--- a/web/_data.js
+++ b/web/_data.js
@@ -1,1 +1,1 @@
-export const api = JSON.parse(await Deno.readTextFile("../dist/api.json"));
+export const api = JSON.parse(await Deno.readTextFile("./dist/api.json"));

--- a/web/_data.js
+++ b/web/_data.js
@@ -1,0 +1,1 @@
+export const api = JSON.parse(await Deno.readTextFile("../dist/api.json"));

--- a/web/_includes/layout.njk
+++ b/web/_includes/layout.njk
@@ -31,8 +31,10 @@
       gap: 1em;
       flex-wrap: wrap;
     }
-    .project-entry::before {
-      content: "👉";
+    .project-entry::marker {
+      content: "👉\00A0";
+      white-space: nowrap;
+      margin-right: 1em;
     }
   </style>
 </head>

--- a/web/_includes/layout.njk
+++ b/web/_includes/layout.njk
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="gl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ngal</title>
+  <style>
+    body {
+      font-family: -apple-system, system-ui, sans-serif;
+      font-size: 0.9em;
+    }
+    .projects {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(20em, 1fr));
+      padding: 5vw;
+      gap: 1em;
+    }
+    .project {
+      background: #efefef;
+      padding: 1em;
+      border-radius: 1em;
+    }
+    .project h2 {
+      margin: 0;
+    }
+    .project-channels {
+      display: flex;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      gap: 1em;
+      flex-wrap: wrap;
+    }
+    .project-entry::before {
+      content: "👉";
+    }
+  </style>
+</head>
+<body>
+  {{ content | safe }}
+</body>
+</html>

--- a/web/index.njk
+++ b/web/index.njk
@@ -1,0 +1,37 @@
+---
+title: ngal
+layout: layout.njk
+---
+
+<main class="projects">
+  {% for item in api.data %}
+  <article class="project">
+    <header>
+      <h2>{{ item.title }}</h2>
+      <p>{{ item.description }}</p>
+    </header>
+
+    <ul class="project-channels">
+      {% for type, channel in item.channels %}
+      <li>
+        <a href="{{ channel.url }}">
+          {{ type }}
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+
+    {% for type, channel in item.channels %}
+      {% if channel.lastEntry %}
+      {% set entry = channel.lastEntry %}
+        <p class="project-entry">
+          <a href="{{ entry.url }}">
+            <strong>{{ type }}:</strong>
+            {{ entry.title }}
+          </a>
+        </p>
+      {% endif %}
+      {% endfor %}
+  </article>
+  {% endfor %}
+</main>

--- a/web/index.njk
+++ b/web/index.njk
@@ -2,6 +2,7 @@
 title: ngal
 layout: layout.njk
 ---
+<p>Última actualización: {{ api.lastUpdated }}</p>
 
 <main class="projects">
   {% for item in api.data %}
@@ -21,17 +22,19 @@ layout: layout.njk
       {% endfor %}
     </ul>
 
+    <ul class="project-updates">
     {% for type, channel in item.channels %}
       {% if channel.lastEntry %}
       {% set entry = channel.lastEntry %}
-        <p class="project-entry">
+        <li class="project-entry">
           <a href="{{ entry.url }}">
             <strong>{{ type }}:</strong>
             {{ entry.title }}
           </a>
-        </p>
+        </li>
       {% endif %}
-      {% endfor %}
+    {% endfor %}
+    </ul>
   </article>
   {% endfor %}
 </main>


### PR DESCRIPTION
Engadín un par de plantillas para xerar un sitio estático cos datos.
Por agora non funciona moi ben (porque as canles que non son urls, como twitter, twitch, etc) non as mostra. Quizáis o build debería xerar as urls finais usando os usernames no json.
A idea é poder xerar automaticamente un sitio estático cos datos, para poder navegar por eles (pódese publicar en github-pages ou onde queiras). Non sei que che parece. Bótalle un ollo e xa me contas.